### PR TITLE
Make pat2dot.py also work with Python3 by fixing 'TypeError: 'dict_ke…

### DIFF
--- a/pat2dot.py
+++ b/pat2dot.py
@@ -89,7 +89,7 @@ def genCGcsv(filename):
     """ Read a csv-formatted CrayPAT callgraph and write out as .csv file """
 
     cgtable = getTables(filename)
-    cgname = cgtable.keys()[0]
+    cgname = list(cgtable.keys())[0]
     cgstr = cgtable[cgname]
 
     with open(cgname, "w") as cgcsv:


### PR DESCRIPTION
…ys' object is not subscriptable'

Verified pat2dot.py now works with both Python3 (3.10.8) and Python2 (2.7.18) and that the .dot file produced is identical. 